### PR TITLE
Pass feed URL to javascript through searchParams

### DIFF
--- a/main/main.js
+++ b/main/main.js
@@ -5,10 +5,10 @@
 
 
 var wpServerlessSearch = (function () {
-  const searchFeed = location.origin + '/wp-content/uploads/wp-sls/search-feed.xml';
   const urlParams = window.location.search;
   const searchModalSelector = 'wp-sls-search-modal';
   const searchModalInput = '.wp-sls-search-field';
+  const searchFeed = searchParams.searchFeed;
   const searchForm = searchParams.searchForm;
   const searchFormInput = searchParams.searchFormInput;
 

--- a/wp-serverless-search.php
+++ b/wp-serverless-search.php
@@ -104,7 +104,11 @@ function wp_sls_search_assets() {
   
   $shifter_js = plugins_url( 'main/main.js', __FILE__ );
 
+  $upload_dir = wp_get_upload_dir();
+  $feed_url = $upload_dir['baseurl'] . '/wp-sls/search-feed.xml';
+
   $search_params = array(
+    'searchFeed' => $feed_url,
     'searchForm' => get_option('wp_sls_search_form'),
     'searchFormInput' => get_option('wp_sls_search_form_input')
   );


### PR DESCRIPTION
If Wordpress is hosted in a subdirectory, the current implementation won't be work.
This fix could resolve the issue.
Also, it seems to be more logical to define this option in the php file.